### PR TITLE
Improve frontend API handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Copy to .env and fill in your credentials
+OPENAI_API_KEY=
+NEO4J_URI=bolt://localhost:7687
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -1,2 +1,52 @@
 # AURA
-Autonomous Understanding &amp; Reasoning Agent
+
+Autonomous Understanding & Reasoning Agent
+
+This repository contains a modular reasoning framework powered by LLMs and a Neo4j memory graph. The backend is implemented with FastAPI and the frontend is a small Next.js interface.
+
+## Backend
+
+Modules live in `backend/` and include agents for planning, memory access, clarification, reasoning, explanations and feedback. The main API is exposed through `api_interface.py`.
+
+Run the API:
+
+```bash
+uvicorn backend.api_interface:app --reload
+```
+
+Environment variables `OPENAI_API_KEY` and optionally `NEO4J_URI`, `NEO4J_USER`,
+and `NEO4J_PASSWORD` are required. Copy `\.env.example` to `\.env` and fill in
+your credentials before starting the service.
+
+## Frontend
+
+A small Next.js application with a ChatGPT‑style interface lives in `frontend/`.
+Run with:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Create a `.env.local` file inside `frontend/` and define `BACKEND_URL` pointing
+to the running FastAPI server (defaults to `http://localhost:8000`). Frontend
+API routes proxy requests to this URL so the user never interacts with the
+backend endpoints directly.
+
+## Tests
+
+Unit tests use mocked LLM and Neo4j responses and can be executed with:
+
+```bash
+pytest
+```
+
+## Quick Start (Windows)
+
+1. Copy `\.env.example` to `\.env` and add your OpenAI and Neo4j credentials.
+2. Run `setup.bat` to create a Python virtual environment and install backend and frontend dependencies.
+3. Launch the application with `start.bat`. This opens the FastAPI backend and Next.js frontend in separate windows.
+4. Stop all services with `stop.bat`.
+
+The frontend still requires a `frontend/.env.local` file containing `BACKEND_URL=http://localhost:8000` (or your custom port).

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+try:
+    from dotenv import load_dotenv  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    load_dotenv = None
+
+env_path = Path(__file__).resolve().parent.parent / ".env"
+if load_dotenv and env_path.exists():
+    load_dotenv(env_path)

--- a/backend/api_interface.py
+++ b/backend/api_interface.py
@@ -1,0 +1,89 @@
+from typing import Any, Dict, List
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from .llm_agent import LLMAgent
+from .planner_agent import plan
+from .memory_agent import MemoryAgent
+from .clarifier_agent import clarify
+from .reasoner_agent import reason
+from .explainer_agent import explain
+from .feedback_agent import apply_feedback
+from .logging import log_event
+
+app = FastAPI()
+
+llm = LLMAgent()
+memory = MemoryAgent()
+
+
+class Goal(BaseModel):
+    goal: str
+
+
+class AskRequest(BaseModel):
+    question: str
+
+
+class Facts(BaseModel):
+    facts: List[Dict[str, Any]]
+
+
+@app.post("/plan")
+def plan_endpoint(goal: Goal) -> Dict[str, Any]:
+    subtasks = plan(goal.goal, llm)
+    log_event("plan_generated", str(subtasks))
+    return {"subtasks": subtasks}
+
+
+@app.post("/ask")
+def ask_endpoint(req: AskRequest) -> Dict[str, Any]:
+    answer = llm.ask(req.question)
+    log_event("asked", req.question)
+    return {"answer": answer}
+
+
+@app.post("/explain")
+def explain_endpoint(data: Dict[str, Any]) -> Dict[str, Any]:
+    reasoning = data.get("reasoning", "")
+    explanation = explain(reasoning, llm)
+    log_event("explain", reasoning)
+    return {"explanation": explanation}
+
+
+@app.post("/learn")
+def learn_endpoint(data: Facts) -> Dict[str, Any]:
+    for f in data.facts:
+        memory.store_fact(
+            f["fact"],
+            f["value"],
+            f.get("source", "api"),
+            f.get("confidence", 1.0),
+        )
+    log_event("facts_learned", str(len(data.facts)))
+    return {"stored": len(data.facts)}
+
+
+@app.post("/ingest")
+def ingest_endpoint(data: Dict[str, Any]) -> Dict[str, Any]:
+    subtask = data.get("subtask", "")
+    facts = memory.retrieve_facts(subtask)
+    log_event("facts_retrieved", subtask)
+    return {"facts": facts}
+
+
+@app.post("/feedback")
+def feedback_endpoint(data: Dict[str, Any]) -> Dict[str, Any]:
+    facts = data.get("facts", [])
+    feedback = data.get("feedback", {})
+    processed = apply_feedback(facts, feedback)
+    for f in processed:
+        memory.store_fact(
+            f["fact"],
+            f["value"],
+            f.get("source", "feedback"),
+            f.get("confidence", 1.0),
+        )
+    log_event("feedback_processed", str(len(processed)))
+    return {"accepted": len(processed)}

--- a/backend/clarifier_agent.py
+++ b/backend/clarifier_agent.py
@@ -1,0 +1,20 @@
+from typing import List
+
+from .llm_agent import LLMAgent
+
+
+def clarify(subtasks: List[str], known_facts: List[str], llm: LLMAgent) -> List[str]:
+    prompt = (
+        "Given the subtasks and known facts, what clarifying questions should be asked?"\
+        f"\nSubtasks: {subtasks}\nFacts: {known_facts}"
+    )
+    response = llm.ask(prompt, mode="clarifier")
+    questions = []
+    for line in response.splitlines():
+        q = line.strip(" -")
+        if not q:
+            continue
+        if not q.endswith("?"):
+            q += "?"
+        questions.append(q)
+    return questions

--- a/backend/explainer_agent.py
+++ b/backend/explainer_agent.py
@@ -1,0 +1,8 @@
+from .llm_agent import LLMAgent
+
+
+def explain(reasoning: str, llm: LLMAgent) -> str:
+    prompt = (
+        "Turn the following reasoning steps into a readable explanation:\n" + reasoning
+    )
+    return llm.ask(prompt, mode="explainer")

--- a/backend/feedback_agent.py
+++ b/backend/feedback_agent.py
@@ -1,0 +1,16 @@
+from typing import Any, Dict, List
+
+
+def apply_feedback(facts: List[Dict[str, Any]], feedback: Dict[int, str]) -> List[Dict[str, Any]]:
+    """Apply user feedback to a list of fact dictionaries."""
+    processed: List[Dict[str, Any]] = []
+    for idx, fact in enumerate(facts):
+        action = feedback.get(idx, "accept")
+        if action == "accept":
+            processed.append(fact)
+        elif action.startswith("edit:"):
+            edited = fact.copy()
+            edited["fact"] = action.split(":", 1)[1]
+            processed.append(edited)
+        # reject -> skip fact
+    return processed

--- a/backend/llm_agent.py
+++ b/backend/llm_agent.py
@@ -1,0 +1,21 @@
+import os
+
+
+class LLMAgent:
+    """Simple OpenAI API wrapper."""
+
+    def __init__(self, api_key: str | None = None, model: str = "gpt-3.5-turbo"):
+        self.api_key = api_key or os.getenv("OPENAI_API_KEY")
+        self.model = model
+
+    def ask(self, prompt: str, mode: str = "default") -> str:
+        """Send a prompt to the OpenAI API and return the response."""
+        try:
+            import openai  # type: ignore
+        except Exception as exc:  # pragma: no cover - library not installed
+            raise RuntimeError("openai package not available") from exc
+
+        openai.api_key = self.api_key
+        messages = [{"role": "user", "content": prompt}]
+        completion = openai.ChatCompletion.create(model=self.model, messages=messages)
+        return completion.choices[0].message["content"].strip()

--- a/backend/logging.py
+++ b/backend/logging.py
@@ -1,0 +1,10 @@
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+
+
+def log_event(event_type: str, details: str) -> None:
+    logging.info("%s - %s", event_type, details)

--- a/backend/memory_agent.py
+++ b/backend/memory_agent.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+class MemoryAgent:
+    """Neo4j-based fact store."""
+
+    def __init__(
+        self,
+        uri: Optional[str] = None,
+        user: Optional[str] = None,
+        password: Optional[str] = None,
+        driver: Any | None = None,
+    ) -> None:
+        if driver is not None:
+            self.driver = driver
+        else:  # pragma: no cover - external dependency
+            from neo4j import GraphDatabase  # type: ignore
+
+            self.driver = GraphDatabase.driver(uri, auth=(user, password))
+
+    def store_fact(
+        self,
+        fact: str,
+        value: str,
+        source: str = "unknown",
+        confidence: float = 1.0,
+    ) -> None:
+        query = (
+            "MERGE (f:Fact {text:$fact})\n"
+            "MERGE (t:Topic {name:$value})\n"
+            "MERGE (f)-[:ABOUT {source:$source, confidence:$confidence}]->(t)"
+        )
+        with self.driver.session() as session:  # type: ignore
+            session.write_transaction(
+                lambda tx: tx.run(
+                    query,
+                    fact=fact,
+                    value=value,
+                    source=source,
+                    confidence=confidence,
+                )
+            )
+
+    def retrieve_facts(self, subtask: str) -> List[Dict[str, Any]]:
+        query = (
+            "MATCH (f:Fact)-[:ABOUT]->(t:Topic)\n"
+            "WHERE f.text CONTAINS $subtask\n"
+            "RETURN f.text AS fact, t.name AS topic"
+        )
+        with self.driver.session() as session:  # type: ignore
+            records = session.read_transaction(
+                lambda tx: list(tx.run(query, subtask=subtask))
+            )
+        return [
+            {"fact": r["fact"], "topic": r["topic"]} for r in records  # type: ignore
+        ]

--- a/backend/planner_agent.py
+++ b/backend/planner_agent.py
@@ -1,0 +1,21 @@
+from typing import List
+
+from .llm_agent import LLMAgent
+
+
+def plan(goal: str, llm: LLMAgent) -> List[str]:
+    """Use an LLM to break a goal into minimal subtasks."""
+    prompt = (
+        "Break down the following goal into 3-7 minimal subtasks as a numbered list."\
+        f"\nGoal: {goal}\nSubtasks:"
+    )
+    response = llm.ask(prompt, mode="planner")
+    tasks: List[str] = []
+    for line in response.splitlines():
+        line = line.strip(" -")
+        if not line:
+            continue
+        if line[0].isdigit() and "." in line:
+            line = line.split(".", 1)[1].strip()
+        tasks.append(line)
+    return tasks[:7]

--- a/backend/reasoner_agent.py
+++ b/backend/reasoner_agent.py
@@ -1,0 +1,17 @@
+from typing import Any, Dict, List
+
+from .llm_agent import LLMAgent
+
+
+def reason(
+    subtasks: List[str],
+    facts: List[Dict[str, Any]],
+    llm: LLMAgent,
+    mode: str = "planning",
+) -> str:
+    prompt = (
+        f"Use mode {mode} to reason over the following subtasks and facts and "
+        "return your decision or plan.\n"\
+        f"Subtasks: {subtasks}\nFacts: {facts}"
+    )
+    return llm.ask(prompt, mode="reasoner")

--- a/frontend/components/ThoughtTrace.tsx
+++ b/frontend/components/ThoughtTrace.tsx
@@ -1,0 +1,11 @@
+interface StepProps {
+  step: string;
+}
+
+export default function ThoughtTrace({ step }: StepProps) {
+  return (
+    <div className="p-2 bg-gray-800 rounded mb-2 text-sm">
+      {step}
+    </div>
+  );
+}

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "aura-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.5.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "tailwindcss": "^3.3.0",
+    "framer-motion": "^10.0.0"
+  }
+}

--- a/frontend/pages/api/ask.ts
+++ b/frontend/pages/api/ask.ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+  const backendUrl = process.env.BACKEND_URL || 'http://localhost:8000';
+  try {
+    const response = await fetch(`${backendUrl}/ask`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(req.body),
+    });
+    const data = await response.json();
+    res.status(200).json(data);
+  } catch (err) {
+    res.status(500).json({ error: 'Backend unreachable' });
+  }
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import Head from 'next/head';
+import { motion } from 'framer-motion';
+
+interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export default function Home() {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+
+  async function send() {
+    if (!input.trim()) return;
+    const userMsg: Message = { role: 'user', content: input };
+    setMessages((m) => [...m, userMsg]);
+    try {
+      const res = await fetch('/api/ask', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question: input }),
+      });
+      const data = await res.json();
+      const botMsg: Message = { role: 'assistant', content: data.answer };
+      setMessages((m) => [...m, botMsg]);
+    } catch (err) {
+      const errorMsg: Message = {
+        role: 'assistant',
+        content: 'Error contacting backend.',
+      };
+      setMessages((m) => [...m, errorMsg]);
+    }
+    setInput('');
+  }
+
+  return (
+    <div className="min-h-screen bg-black text-white flex flex-col items-center p-6">
+      <Head>
+        <title>AURA</title>
+      </Head>
+      <motion.h1
+        className="text-4xl mb-6"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+      >
+        AURA
+      </motion.h1>
+      <div className="w-full max-w-2xl flex-1 overflow-y-auto mb-4">
+        {messages.map((m, idx) => (
+          <div
+            key={idx}
+            className={`p-3 my-2 rounded-lg bg-gray-800 ${m.role === 'user' ? 'self-end' : 'self-start'} w-fit max-w-full`}
+          >
+            {m.content}
+          </div>
+        ))}
+      </div>
+      <div className="w-full max-w-2xl flex">
+        <input
+          className="flex-1 p-2 bg-gray-700 text-white rounded-l-md focus:outline-none"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Type your message..."
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              send();
+            }
+          }}
+        />
+        <button
+          className="px-4 bg-blue-600 rounded-r-md"
+          onClick={send}
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn
+openai
+neo4j
+pydantic
+pytest
+python-dotenv

--- a/setup.bat
+++ b/setup.bat
@@ -1,0 +1,8 @@
+@echo off
+python -m venv env
+call env\Scripts\activate
+pip install -r requirements.txt
+cd frontend
+npm install
+cd ..
+echo Setup complete. Fill in .env and frontend/.env.local before running start.bat.

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,4 @@
+@echo off
+call env\Scripts\activate
+start "BACKEND" uvicorn backend.api_interface:app --reload
+start "FRONTEND" cmd /k "cd frontend && npm run dev"

--- a/stop.bat
+++ b/stop.bat
@@ -1,0 +1,4 @@
+@echo off
+for /f "tokens=5" %%p in ('netstat -aon ^| findstr :8000') do taskkill /PID %%p /F >nul 2>&1
+for /f "tokens=5" %%p in ('netstat -aon ^| findstr :3000') do taskkill /PID %%p /F >nul 2>&1
+echo Processes on ports 8000 and 3000 stopped.

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,87 @@
+from backend.planner_agent import plan
+from backend.memory_agent import MemoryAgent
+from backend.clarifier_agent import clarify
+from backend.reasoner_agent import reason
+from backend.explainer_agent import explain
+from backend.feedback_agent import apply_feedback
+
+
+class FakeLLM:
+    def __init__(self, responses):
+        self.responses = list(responses)
+
+    def ask(self, prompt, mode="default"):
+        return self.responses.pop(0)
+
+
+class FakeTx:
+    def __init__(self, store):
+        self.store = store
+
+    def run(self, query, **params):
+        self.store.append((query, params))
+        return [{"fact": "A", "topic": "B"}]
+
+
+class FakeSession:
+    def __init__(self, store):
+        self.store = store
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def write_transaction(self, func):
+        tx = FakeTx(self.store)
+        func(tx)
+
+    def read_transaction(self, func):
+        tx = FakeTx(self.store)
+        return func(tx)
+
+
+class FakeDriver:
+    def __init__(self):
+        self.store = []
+
+    def session(self):
+        return FakeSession(self.store)
+
+
+def test_planner_agent_returns_subtasks():
+    llm = FakeLLM(["1. A\n2. B\n3. C"])
+    subtasks = plan("goal", llm)
+    assert subtasks == ["A", "B", "C"]
+
+
+def test_memory_agent_store_and_retrieve():
+    driver = FakeDriver()
+    agent = MemoryAgent(driver=driver)
+    agent.store_fact("f", "t", "s", 1.0)
+    facts = agent.retrieve_facts("f")
+    assert driver.store
+    assert facts == [{"fact": "A", "topic": "B"}]
+
+
+def test_clarifier_agent():
+    llm = FakeLLM(["Question 1?\nQuestion 2?"])
+    questions = clarify(["sub"], ["fact"], llm)
+    assert questions == ["Question 1?", "Question 2?"]
+
+
+def test_reasoner_agent():
+    llm = FakeLLM(["Decision"])
+    assert reason(["s"], [{"fact": "A"}], llm) == "Decision"
+
+
+def test_explainer_agent():
+    llm = FakeLLM(["Explanation"])
+    assert explain("Reason", llm) == "Explanation"
+
+
+def test_feedback_agent():
+    facts = [{"fact": "A", "value": "B"}]
+    feedback = {0: "reject"}
+    assert apply_feedback(facts, feedback) == []


### PR DESCRIPTION
## Summary
- proxy backend `/ask` through a Next.js API route
- update chat UI to call local proxy instead of backend directly
- document `BACKEND_URL` environment variable for the frontend
- add Windows quick start guide and batch scripts
- provide `.env.example` and load env automatically

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f1c7bb550832c9f9afa9bc72e8c7b