### PR TITLE
Improve env var defaults for MemoryAgent

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ uvicorn backend.api_interface:app --reload
 
 Environment variables `OPENAI_API_KEY` and optionally `NEO4J_URI`, `NEO4J_USER`,
 and `NEO4J_PASSWORD` are required. Copy `\.env.example` to `\.env` and fill in
-your credentials before starting the service.
+your credentials before starting the service. When `MemoryAgent` is created
+without explicit parameters it reads these values from the environment.
 
 ## Frontend
 

--- a/backend/memory_agent.py
+++ b/backend/memory_agent.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
+import os
 
 
 class MemoryAgent:
@@ -17,6 +18,14 @@ class MemoryAgent:
             self.driver = driver
         else:  # pragma: no cover - external dependency
             from neo4j import GraphDatabase  # type: ignore
+
+            uri = uri or os.getenv("NEO4J_URI")
+            user = user or os.getenv("NEO4J_USER")
+            password = password or os.getenv("NEO4J_PASSWORD")
+            if not uri:
+                raise ValueError(
+                    "Neo4j URI must be provided via parameter or NEO4J_URI environment variable"
+                )
 
             self.driver = GraphDatabase.driver(uri, auth=(user, password))
 


### PR DESCRIPTION
## Summary
- read Neo4j connection settings from environment in `MemoryAgent`
- document how `MemoryAgent` uses env vars by default

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f23a66ce4832cb32d34579b916ea1